### PR TITLE
refactor: fix plugin name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ const injectReadme = (option: Partial<Option> = {}) => {
     .use(rehypeStringify);
   let pathToConfig: string | undefined;
   const plugin = {
-    name: "vite-plugin-readme-inject",
+    name: "vite-plugin-inject-readme",
     configResolved: ({ configFile }) => {
       pathToConfig = configFile;
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,8 @@ const injectReadme = (option: Partial<Option> = {}) => {
     },
     transformIndexHtml: async (html) => {
       if (pathToConfig == null) {
-        throw new Error("unprocessable error");
+        // NOTE: if specify this plugin, user have to use vite.config.ts. So this block is not reachable.
+        throw new Error("vite config is not found");
       }
       const { readme = "./README.md", marker = "<!-- README.md -->" } = option;
       const readmePath = resolve(dirname(pathToConfig), readme);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const injectReadme = (option: Partial<Option> = {}) => {
     },
     transformIndexHtml: async (html) => {
       if (pathToConfig == null) {
-        // NOTE: if specify this plugin, user have to use vite.config.ts. So this block is not reachable.
+        // NOTE: This plugin requires a vite.config.ts file, so this block is unreachable.
         throw new Error("vite config is not found");
       }
       const { readme = "./README.md", marker = "<!-- README.md -->" } = option;


### PR DESCRIPTION
- **refactor: fix the plugin name**
- **refactor: add more information**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin name to "vite-plugin-inject-readme".
  * Improved error messaging when the Vite config file is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->