### PR TITLE
ci: setup node before publish

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,14 +45,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - name: setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
-      - name: setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          run_install: true
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+      - run: pnpm install
       - run: pnpm run check
   status-check:
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,12 @@ jobs:
           persist-credentials: false
       - name: Install pnpm with pnpm install
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          run_install: true
+          node-version: latest
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+      - run: pnpm install
       - run: pnpm publish --provenance --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
seems to need .npmrc

Release-As: 1.0.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow setup for dependency installation and caching in automated checks and release processes to improve clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->