### PR TITLE
ci: use oidc token instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: latest
           registry-url: https://registry.npmjs.org
           cache: pnpm
+      - name: Update npm to 11.5.1 or higher
+        run: npm install --global npm@latest
       - run: pnpm install
       - run: pnpm publish --provenance --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline reliability by updating npm to the latest version during the publish process, ensuring compatibility with publishing tools.
  * Streamlined authentication handling in the publish workflow for cleaner configuration.
  * No user-facing changes; these updates focus on stability and consistency of package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->