### PR TITLE
chore: add version to devEngines.packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	"devEngines": {
 		"packageManager": {
 			"name": "pnpm",
+			"version": "10.33.0",
 			"onFail": "error"
 		}
 	}


### PR DESCRIPTION
## Summary

Add version specifier to `devEngines.packageManager` to match the `packageManager` field.

## Details

`pnpm/action-setup` v6 prioritizes `devEngines.packageManager` over the `packageManager` field. Without a version in `devEngines.packageManager`, v6 installs an unintended pnpm version, causing `ERR_PNPM_IGNORED_BUILDS` failures in CI. By specifying `10.33.0` (the same version as `packageManager`), the correct pnpm version is used regardless of which field takes precedence.

## Confirmation

- Verify that the `pkg-pr-new` job passes on PR #232 after this change is merged

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration to ensure consistency across development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->