### PR TITLE
chore: change devEngines.packageManager onFail to download

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"packageManager": {
 			"name": "pnpm",
 			"version": "10.33.0",
-			"onFail": "error"
+			"onFail": "download"
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Change `devEngines.packageManager.onFail` from `"error"` to `"download"`.

## Details

With `"download"`, pnpm can automatically resolve and download the specified version instead of failing. For npm and yarn, this behaves identically to `"error"` since they do not support the `"download"` value.

## Confirmation

- Run `pnpm install` and verify it succeeds
- Run `npm install` and verify it still rejects with `EBADDEVENGINES`

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration to automatically download required dependencies when unavailable instead of throwing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->